### PR TITLE
Add example Docker files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,14 @@
+# Docker
+.docker
+.dockerignore
+
+# Environment
+.env
+
+# Git
+.git
+.gitignore
+
+# Node
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# Adjust NODE_VERSION as desired
+ARG NODE_VERSION=20.5.0
+FROM node:${NODE_VERSION}-alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+# Set production environment
+ENV NODE_ENV=production
+
+# Install node modules
+COPY package*.json ./
+RUN npm ci
+
+# Copy application code
+COPY . .
+
+# Expose port
+EXPOSE 3000
+
+# Start the server by default, this can be overwritten at runtime
+CMD [ "npx", "indiekit", "serve" ]

--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ Some values shouldn’t be made public. Instead, they should be saved as environ
 Once you have updated the configuration file with your own values, and ensured environment variables are present, you can start the server using the following command:
 
 `npm start`
+
+## Server deployment using Docker
+
+If you want to deploy your server using [Docker](https://www.docker.com), the following files are provided as a starting point:
+
+* `.dockerignore`
+* `docker-compose.yml`
+* `Dockerfile`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.9"
+services:
+  indiekit:
+    container_name: indiekit
+    image: getindiekit/indiekit
+    restart: always
+    build: .
+    ports:
+      - "${HTTP_PORT:-3000}:3000"
+    environment:
+      - MONGO_URL=mongodb://$MONGO_INITDB_ROOT_USERNAME:$MONGO_INITDB_ROOT_PASSWORD@mongo
+      - PASSWORD_SECRET
+      - SECRET
+  mongo:
+    container_name: mongo
+    image: mongo:4
+    restart: always
+    volumes:
+      - mongo:/data/db
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME
+      - MONGO_INITDB_ROOT_PASSWORD
+
+volumes:
+  mongo:
+    external: true


### PR DESCRIPTION
Adds `.dockerignore`, `docker-compose.yml` and `Dockerfile` files. These should be a good starting point for anyone interested in using Docker, and can of course be refined and tweaked over time.

Once I’ve tested this example config using a few different providers, will look to provide an option to create these files using the project initialiser script.